### PR TITLE
Add unrs-resolver to pnpm.onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "@parcel/watcher"
+      "@parcel/watcher",
+      "unrs-resolver"
     ],
     "ignoredBuiltDependencies": [
       "core-js",


### PR DESCRIPTION
Build `unrs-resolver`, a new transitive dependency of `eslint-config-upleveled`, to avoid Preflight failures such as:

```
ExecaError: Command failed with exit code 1: pnpm install

Lockfile is up to date, resolution step is skipped
Progress: resolved 1, reused 0, downloaded 0, added 0
Packages: +1334
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 1334, reused 86, downloaded 13, added 0
Progress: resolved 1334, reused 86, downloaded 35, added 8
Progress: resolved 1334, reused 86, downloaded 126, added 38
Progress: resolved 1334, reused 86, downloaded 194, added 62
Progress: resolved 1334, reused 86, downloaded 349, added 122
Progress: resolved 1334, reused 86, downloaded 464, added 174
Progress: resolved 1334, reused 86, downloaded 673, added 262
Progress: resolved 1334, reused 86, downloaded 813, added 318
Progress: resolved 1334, reused 86, downloaded 985, added 393
Progress: resolved 1334, reused 86, downloaded 1121, added 449
Progress: resolved 1334, reused 86, downloaded 1238, added 501
Progress: resolved 1334, reused 86, downloaded 1247, added 842
Progress: resolved 1334, reused 86, downloaded 1247, added 1331
Progress: resolved 1334, reused 86, downloaded 1247, added 1334, done
.../node_modules/@parcel/watcher install$ node scripts/build-from-source.js
.../node_modules/@parcel/watcher install: Done

dependencies:
+ @upleveled/react-scripts 5.1.2
+ file-saver 2.0.5
+ react 19.0.0
+ react-dom 19.0.0
+ sass 1.86.0

devDependencies:
+ @jest/globals 29.7.0
+ @testing-library/dom 10.4.0
+ @testing-library/jest-dom 6.6.3
+ @testing-library/react 16.2.0
+ @testing-library/user-event 13.5.0
+ @types/file-saver 2.0.7
+ @types/node 22.13.13
+ @types/react 19.0.12
+ @types/react-dom 19.0.4
+ @types/testing-library__jest-dom 5.14.9
+ eslint 8.57.1
+ eslint-config-upleveled 9.2.6
+ jest 29.7.0
+ prettier 3.5.3
+ stylelint 16.16.0
+ stylelint-config-upleveled 1.1.10
+ typescript 5.8.2

\u2009ERR_PNPM_IGNORED_BUILDS\u2009 Ignored build scripts: unrs-resolver
```